### PR TITLE
Various changes to the default engines and a few more

### DIFF
--- a/WebSearch/src/main/assets/opensearch/duckduckgo.xml
+++ b/WebSearch/src/main/assets/opensearch/duckduckgo.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"> 
+  <ShortName>DuckDuckGo</ShortName> 
+  <Description>Search DuckDuckGo</Description> 
+  <InputEncoding>UTF-8</InputEncoding> 
+  <LongName>DuckDuckGo Search</LongName> 
+  <Image height="16" width="16">data:image/x-icon;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAB8lBMVEUAAADkRQzjPwPjQQXkRQ3iPwTiQQXgPQPeQgrcOwPVNgDVNQDWOgbTMwDRMgDQMwDSMwDRNwTQLgDRJgDSJwDSLgDSNwTjOgDiOADjOQDkPADhQAXzs5v+/fv////0vKbiRQvgPQHpdUr85NzuknPdKgDcIwDnZzj2w7HqeU/gPQLsimb/+PftjWn97Obpb0LdJQDeLQDtjmvsi2jgSBDnbULgOQD/39HgLQDeMgDpeFLgSBH0v670uqbaJQD2qImWvP/G1Ob5+/3u//+fvvXyp47dMwDaLwD0u6v0v6/aNQDiXi/aKQD3qozU7/8gSY2vvtg0ZK/OqLDaKQHYKgLgWTfaNADZMgDZMADZLADzqpD7//+xwdz//9H/5Bn/7Bn//ADofADYMADYMQDZOgPXLgDiZDj//97/0AD3tQDvlgHZOgbXLATXMADWMgDfXjLVLQD///z+0AD/3Rn/yRnwnQDcVjbVMQDyv67wuKTSJwDRHQD+8O/tg3/iQQDwhAHnawHWMADvtKfyva7XQxHga0bQGQD2vbH/u8LXIQCmPQzja07XQxLliGn99fPkcVHvhnGZ5VguvUU5wktBwCcAgxzydVv/8/XmiGngdlL+ysi3+I8LtCE80V6P3YmX4sDleljSNQLzr6D7sKPXNQTSIwAEAbMrAAAAF3RSTlMARqSkRvPz80PTpKRG3fPe3hio9/eoGP50jNsAAAABYktHRB5yCiArAAAAyElEQVQYGQXBvUqCYRiA4fu2V9Tn+UQddI3aCpxaOoU6iU4gcqqpoYbALXBuCuoYmttamqJDiEoh4YP+MOi6BNCh+uYKEGiOVNCXXxA2XDVV/UyfKbRCXTLQWAxbP2vt8Ue/uYDvfim91615sb2um6rqtrr/NFb1cUf1Ybd06areU6lSlYpK79jzK1SyJOkfhOl8JGEcqV5zoKrTRqO6yUzIzNu46ijdM1VV9bhuUJ/nZURExLRzUiPQm3kKXHi4BAEGOmOi78A/L1QoU/VHoTsAAAAldEVYdGRhdGU6Y3JlYXRlADIwMTQtMDEtMTlUMjA6MDE6MTEtMDU6MDAuET6cAAAAJXRFWHRkYXRlOm1vZGlmeQAyMDE0LTAxLTE5VDIwOjAxOjExLTA1OjAwX0yGIAAAAABJRU5ErkJggg==</Image>
+  <Url type="text/html" method="get" template="https://duckduckgo.com/?q={searchTerms}"/>
+  <Url type="application/x-suggestions+json" template="https://ac.duckduckgo.com/ac/?q={searchTerms}&amp;type=list"/>
+</OpenSearchDescription> 

--- a/WebSearch/src/main/assets/opensearch/kickass.xml
+++ b/WebSearch/src/main/assets/opensearch/kickass.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
-	<moz:SearchForm>http://kickass.to/</moz:SearchForm>
-	<ShortName>KickassTorrents</ShortName>
-	<LongName>KickassTorrents Torrent Search</LongName>
-	<Description>KickassTorrents torrent search Firefox extension helps you search and download TV series, movies, music, ebooks and games. KickassTorrents is a fast growing torrent search engine. 6 millions torrents, friendly community.</Description>
-	<Image height="16" width="16" type="image/vnd.microsoft.icon">http://kastatic.com/images/favicon.ico</Image>
-	<Contact>admin@kickass.to</Contact>
-	<Url type="text/html" template="http://kickass.to/search/{searchTerms}/?from=opensearch"/>
-	<Url type="application/rss+xml" template="http://kickass.to/search/{searchTerms}/?rss=1&amp;from=opensearch"/>
-	<Url type="application/x-suggestions+json" template="http://kickass.to/get_queries.php?q={searchTerms}&amp;limit=10&amp;json=1"/>
-	<Url type="application/opensearchdescription+xml" template="http://kickass.to/opensearch.xml"/>
+	<moz:SearchForm>http://kat.cr/</moz:SearchForm>
+	<ShortName>Kickass Torrents</ShortName>
+	<LongName>Kickass Torrents Torrent Search</LongName>
+	<Description>6 millions torrents, friendly community</Description>
+	<Image height="16" width="16" type="image/vnd.microsoft.icon">http://kat.cr/content/images/logos/kickasstorrents_16x16.ico</Image>
+	<Contact>admin@kat.cr</Contact>
+	<Url type="text/html" template="http://kat.cr/search/{searchTerms}/?from=opensearch"/>
+	<Url type="application/rss+xml" template="http://kat.cr/search/{searchTerms}/?rss=1&amp;from=opensearch"/>
+	<Url type="application/x-suggestions+json" template="http://kat.cr/get_queries.php?q={searchTerms}&amp;limit=10&amp;json=1"/>
+	<Url type="application/opensearchdescription+xml" template="http://kat.cr/opensearch.xml"/>
 	<Query role="example" searchTerms="720p"/>
-	<Developer>KickassTorrents</Developer>
+	<Developer>Kickass Torrents</Developer>
 	<OutputEncoding>UTF-8</OutputEncoding>
 	<InputEncoding>UTF-8</InputEncoding>
 	<Language>en-us</Language>

--- a/WebSearch/src/main/assets/opensearch/kickass.xml
+++ b/WebSearch/src/main/assets/opensearch/kickass.xml
@@ -6,9 +6,9 @@
 	<Description>10 millions torrents indexed; friendly community</Description>
 	<Image height="16" width="16" type="image/vnd.microsoft.icon">http://kat.cr/content/images/logos/kickasstorrents_16x16.ico</Image>
 	<Contact>admin@kat.cr</Contact>
-	<Url type="text/html" template="http://kat.cr/usearch/?q={searchTerms}&from=opensearch"/>
-	<Url type="application/rss+xml" template="http://kat.cr/usearch/?q={searchTerms}&rss=1&from=opensearch"/>
-	<Url type="application/x-suggestions+json" template="http://kat.cr/get_queries.php?q={searchTerms}&limit=10&json=1"/>
+	<Url type="text/html" template="http://kat.cr/usearch/?q={searchTerms}&amp;from=opensearch"/>
+	<Url type="application/rss+xml" template="http://kat.cr/usearch/?q={searchTerms}&amp;rss=1&amp;from=opensearch"/>
+	<Url type="application/x-suggestions+json" template="http://kat.cr/get_queries.php?q={searchTerms}&amp;limit=10&amp;json=1"/>
 	<Url type="application/opensearchdescription+xml" template="http://kat.cr/opensearch.xml"/>
 	<Query role="example" searchTerms="720p"/>
 	<Developer>Kickass Torrents</Developer>

--- a/WebSearch/src/main/assets/opensearch/kickass.xml
+++ b/WebSearch/src/main/assets/opensearch/kickass.xml
@@ -3,12 +3,12 @@
 	<moz:SearchForm>http://kat.cr/</moz:SearchForm>
 	<ShortName>Kickass Torrents</ShortName>
 	<LongName>Kickass Torrents Torrent Search</LongName>
-	<Description>6 millions torrents, friendly community</Description>
+	<Description>10 millions torrents indexed; friendly community</Description>
 	<Image height="16" width="16" type="image/vnd.microsoft.icon">http://kat.cr/content/images/logos/kickasstorrents_16x16.ico</Image>
 	<Contact>admin@kat.cr</Contact>
-	<Url type="text/html" template="http://kat.cr/search/{searchTerms}/?from=opensearch"/>
-	<Url type="application/rss+xml" template="http://kat.cr/search/{searchTerms}/?rss=1&amp;from=opensearch"/>
-	<Url type="application/x-suggestions+json" template="http://kat.cr/get_queries.php?q={searchTerms}&amp;limit=10&amp;json=1"/>
+	<Url type="text/html" template="http://kat.cr/usearch/?q={searchTerms}&from=opensearch"/>
+	<Url type="application/rss+xml" template="http://kat.cr/usearch/?q={searchTerms}&rss=1&from=opensearch"/>
+	<Url type="application/x-suggestions+json" template="http://kat.cr/get_queries.php?q={searchTerms}&limit=10&json=1"/>
 	<Url type="application/opensearchdescription+xml" template="http://kat.cr/opensearch.xml"/>
 	<Query role="example" searchTerms="720p"/>
 	<Developer>Kickass Torrents</Developer>

--- a/WebSearch/src/main/assets/opensearch/stackoverflow.xml
+++ b/WebSearch/src/main/assets/opensearch/stackoverflow.xml
@@ -3,6 +3,6 @@
   <ShortName>Stack Overflow</ShortName>
   <Description>Search Stack Overflow: Q&amp;A for professional and enthusiast programmers</Description>
   <InputEncoding>UTF-8</InputEncoding>
-  <Image width="16" height="16" type="image/x-icon">http://sstatic.net/stackoverflow/img/favicon.ico</Image>
-  <Url type="text/html" method="get" template="http://stackoverflow.com/search?q={searchTerms}"></Url>
+  <Image width="16" height="16" type="image/x-icon">https://sstatic.net/stackoverflow/img/favicon.ico</Image>
+  <Url type="text/html" method="get" template="https://stackoverflow.com/search?q={searchTerms}"></Url>
 </OpenSearchDescription>

--- a/WebSearch/src/main/assets/opensearch/thepiratebay.xml
+++ b/WebSearch/src/main/assets/opensearch/thepiratebay.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
         <ShortName>The Pirate Bay</ShortName>
-        <Description>Search The Pirate Bay</Description>
+        <Description>The Pirate Bay maintains a large bittorrent index</Description>
         <InputEncoding>UTF-8</InputEncoding>
-        <Image height="16" width="16" type="image/x-icon">http://thepiratebay.se/favicon.ico</Image>
-        <Url type="text/html" method="GET" template="http://thepiratebay.se/search/{searchTerms}"/>
-        <SearchForm>http://thepiratebay.se/</SearchForm>
+        <Image height="16" width="16" type="image/x-icon">https://thepiratebay.se/favicon.ico</Image>
+        <Url type="text/html" method="GET" template="https://thepiratebay.se/search/{searchTerms}"/>
+        <SearchForm>https://thepiratebay.se/</SearchForm>
 </OpenSearchDescription>
 

--- a/WebSearch/src/main/assets/opensearch/torrentz.xml
+++ b/WebSearch/src/main/assets/opensearch/torrentz.xml
@@ -5,7 +5,7 @@
  <Tags>torrentz torrent torrents bittorrent search engine</Tags>
  <Contact>admin@torrentz.eu</Contact>
  <InputEncoding>UTF-8</InputEncoding>
- <Url type="text/html" template="http://torrentz.eu/search?q={searchTerms}" />
- <Url type="application/x-suggestions+json" template="http://torrentz.eu/suggestions.php?q={searchTerms}" />
- <Image height="16" width="16" type="image/x-icon">http://torrentz.eu/favicon.ico</Image>
+ <Url type="text/html" template="https://torrentz.eu/search?q={searchTerms}" />
+ <Url type="application/x-suggestions+json" template="https://torrentz.eu/suggestions.php?q={searchTerms}" />
+ <Image height="16" width="16" type="image/x-icon">https://torrentz.eu/favicon.ico</Image>
 </OpenSearchDescription>

--- a/WebSearch/src/main/assets/opensearch/wikipedia-fr.xml
+++ b/WebSearch/src/main/assets/opensearch/wikipedia-fr.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?><OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+	<ShortName>Wikipedia (fr)</ShortName>
+	<Description>Encyclopedia in French</Description>
+	<Image height="16" width="16" type="image/x-icon">https://bits.wikimedia.org/favicon/wikipedia.ico</Image>
+	<Url type="text/html" method="get" template="https://fr.wikipedia.org/w/index.php?title=Special:Search&amp;search={searchTerms}" />
+	<Url type="application/x-suggestions+json" method="get" template="https://fr.wikipedia.org/w/api.php?action=opensearch&amp;search={searchTerms}&amp;namespace=0" />
+	<Url type="application/x-suggestions+xml" method="get" template="https://fr.wikipedia.org/w/api.php?action=opensearch&amp;format=xml&amp;search={searchTerms}&amp;namespace=0" />
+	<moz:SearchForm>https://fr.wikipedia.org/wiki/Special:Search</moz:SearchForm>
+</OpenSearchDescription>

--- a/WebSearch/src/main/assets/opensearch/wikipedia-fr.xml
+++ b/WebSearch/src/main/assets/opensearch/wikipedia-fr.xml
@@ -1,9 +1,1 @@
-<?xml version="1.0"?><OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
-	<ShortName>Wikipedia (fr)</ShortName>
-	<Description>Encyclopedia in French</Description>
-	<Image height="16" width="16" type="image/x-icon">https://bits.wikimedia.org/favicon/wikipedia.ico</Image>
-	<Url type="text/html" method="get" template="https://fr.wikipedia.org/w/index.php?title=Special:Search&amp;search={searchTerms}" />
-	<Url type="application/x-suggestions+json" method="get" template="https://fr.wikipedia.org/w/api.php?action=opensearch&amp;search={searchTerms}&amp;namespace=0" />
-	<Url type="application/x-suggestions+xml" method="get" template="https://fr.wikipedia.org/w/api.php?action=opensearch&amp;format=xml&amp;search={searchTerms}&amp;namespace=0" />
-	<moz:SearchForm>https://fr.wikipedia.org/wiki/Special:Search</moz:SearchForm>
-</OpenSearchDescription>
+<?xml version="1.0"?><OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/"><ShortName>Wikipédia (fr)</ShortName><Description>Wikipédia (fr)</Description><Image height="16" width="16" type="image/x-icon">https://fr.wikipedia.org/static/favicon/wikipedia.ico</Image><Url type="text/html" method="get" template="https://fr.wikipedia.org/w/index.php?title=Sp%C3%A9cial:Recherche&amp;search={searchTerms}" /><Url type="application/x-suggestions+json" method="get" template="https://fr.wikipedia.org/w/api.php?action=opensearch&amp;search={searchTerms}&amp;namespace=0" /><Url type="application/x-suggestions+xml" method="get" template="https://fr.wikipedia.org/w/api.php?action=opensearch&amp;format=xml&amp;search={searchTerms}&amp;namespace=0" /><moz:SearchForm>https://fr.wikipedia.org/wiki/Sp%C3%A9cial:Recherche</moz:SearchForm></OpenSearchDescription>

--- a/WebSearch/src/main/assets/opensearch/wikipedia.xml
+++ b/WebSearch/src/main/assets/opensearch/wikipedia.xml
@@ -1,1 +1,9 @@
-<?xml version="1.0"?><OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/"><ShortName>Wikipedia (en)</ShortName><Description>Wikipedia (en)</Description><Image height="16" width="16" type="image/x-icon">http://bits.wikimedia.org/favicon/wikipedia.ico</Image><Url type="text/html" method="get" template="http://en.wikipedia.org/w/index.php?title=Special:Search&amp;search={searchTerms}" /><Url type="application/x-suggestions+json" method="get" template="http://en.wikipedia.org/w/api.php?action=opensearch&amp;search={searchTerms}&amp;namespace=0" /><Url type="application/x-suggestions+xml" method="get" template="http://en.wikipedia.org/w/api.php?action=opensearch&amp;format=xml&amp;search={searchTerms}&amp;namespace=0" /><moz:SearchForm>http://en.wikipedia.org/wiki/Special:Search</moz:SearchForm></OpenSearchDescription>
+<?xml version="1.0"?><OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+	<ShortName>Wikipedia (en)</ShortName>
+	<Description>Encyclopedia in English</Description>
+	<Image height="16" width="16" type="image/x-icon">https://bits.wikimedia.org/favicon/wikipedia.ico</Image>
+	<Url type="text/html" method="get" template="https://en.wikipedia.org/w/index.php?title=Special:Search&amp;search={searchTerms}" />
+	<Url type="application/x-suggestions+json" method="get" template="https://en.wikipedia.org/w/api.php?action=opensearch&amp;search={searchTerms}&amp;namespace=0" />
+	<Url type="application/x-suggestions+xml" method="get" template="https://en.wikipedia.org/w/api.php?action=opensearch&amp;format=xml&amp;search={searchTerms}&amp;namespace=0" />
+	<moz:SearchForm>https://en.wikipedia.org/wiki/Special:Search</moz:SearchForm>
+</OpenSearchDescription>

--- a/WebSearch/src/main/assets/opensearch/wikipedia.xml
+++ b/WebSearch/src/main/assets/opensearch/wikipedia.xml
@@ -1,9 +1,1 @@
-<?xml version="1.0"?><OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
-	<ShortName>Wikipedia (en)</ShortName>
-	<Description>Encyclopedia in English</Description>
-	<Image height="16" width="16" type="image/x-icon">https://bits.wikimedia.org/favicon/wikipedia.ico</Image>
-	<Url type="text/html" method="get" template="https://en.wikipedia.org/w/index.php?title=Special:Search&amp;search={searchTerms}" />
-	<Url type="application/x-suggestions+json" method="get" template="https://en.wikipedia.org/w/api.php?action=opensearch&amp;search={searchTerms}&amp;namespace=0" />
-	<Url type="application/x-suggestions+xml" method="get" template="https://en.wikipedia.org/w/api.php?action=opensearch&amp;format=xml&amp;search={searchTerms}&amp;namespace=0" />
-	<moz:SearchForm>https://en.wikipedia.org/wiki/Special:Search</moz:SearchForm>
-</OpenSearchDescription>
+<?xml version="1.0"?><OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/"><ShortName>Wikipedia (en)</ShortName><Description>Wikipedia (en)</Description><Image height="16" width="16" type="image/x-icon">https://en.wikipedia.org/static/favicon/wikipedia.ico</Image><Url type="text/html" method="get" template="https://en.wikipedia.org/w/index.php?title=Special:Search&amp;search={searchTerms}" /><Url type="application/x-suggestions+json" method="get" template="https://en.wikipedia.org/w/api.php?action=opensearch&amp;search={searchTerms}&amp;namespace=0" /><Url type="application/x-suggestions+xml" method="get" template="https://en.wikipedia.org/w/api.php?action=opensearch&amp;format=xml&amp;search={searchTerms}&amp;namespace=0" /><moz:SearchForm>https://en.wikipedia.org/wiki/Special:Search</moz:SearchForm></OpenSearchDescription>

--- a/WebSearch/src/main/assets/opensearch/wiktionary-fr.xml
+++ b/WebSearch/src/main/assets/opensearch/wiktionary-fr.xml
@@ -5,5 +5,5 @@
 	<Url type="text/html" method="get" template="https://fr.wiktionary.org/w/index.php?title=Special:Search&amp;search={searchTerms}" />
 	<Url type="application/x-suggestions+json" method="get" template="https://fr.wiktionary.org/w/api.php?action=opensearch&amp;search={searchTerms}&amp;namespace=0" />
 	<Url type="application/x-suggestions+xml" method="get" template="https://fr.wiktionary.org/w/api.php?action=opensearch&amp;format=xml&amp;search={searchTerms}&amp;namespace=0" />
-	<moz:SearchForm>https://fr.wikipedia.org/wiki/Special:Search</moz:SearchForm>
+	<moz:SearchForm>https://fr.wiktionary.org/wiki/Special:Search</moz:SearchForm>
 </OpenSearchDescription>

--- a/WebSearch/src/main/assets/opensearch/wiktionary-fr.xml
+++ b/WebSearch/src/main/assets/opensearch/wiktionary-fr.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?><OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+	<ShortName>Wiktionary (fr)</ShortName>
+	<Description>Dictionary and translator in the French language</Description>
+	<Image height="16" width="16" type="image/x-icon">https://fr.wiktionary.org/favicon.ico</Image>
+	<Url type="text/html" method="get" template="https://fr.wiktionary.org/w/index.php?title=Special:Search&amp;search={searchTerms}" />
+	<Url type="application/x-suggestions+json" method="get" template="https://fr.wiktionary.org/w/api.php?action=opensearch&amp;search={searchTerms}&amp;namespace=0" />
+	<Url type="application/x-suggestions+xml" method="get" template="https://fr.wiktionary.org/w/api.php?action=opensearch&amp;format=xml&amp;search={searchTerms}&amp;namespace=0" />
+	<moz:SearchForm>https://fr.wikipedia.org/wiki/Special:Search</moz:SearchForm>
+</OpenSearchDescription>

--- a/WebSearch/src/main/assets/opensearch/wiktionary-fr.xml
+++ b/WebSearch/src/main/assets/opensearch/wiktionary-fr.xml
@@ -1,9 +1,1 @@
-<?xml version="1.0"?><OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
-	<ShortName>Wiktionary (fr)</ShortName>
-	<Description>Dictionary and translator in the French language</Description>
-	<Image height="16" width="16" type="image/x-icon">https://fr.wiktionary.org/favicon.ico</Image>
-	<Url type="text/html" method="get" template="https://fr.wiktionary.org/w/index.php?title=Special:Search&amp;search={searchTerms}" />
-	<Url type="application/x-suggestions+json" method="get" template="https://fr.wiktionary.org/w/api.php?action=opensearch&amp;search={searchTerms}&amp;namespace=0" />
-	<Url type="application/x-suggestions+xml" method="get" template="https://fr.wiktionary.org/w/api.php?action=opensearch&amp;format=xml&amp;search={searchTerms}&amp;namespace=0" />
-	<moz:SearchForm>https://fr.wiktionary.org/wiki/Special:Search</moz:SearchForm>
-</OpenSearchDescription>
+<?xml version="1.0"?><OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/"><ShortName>Wiktionnaire (fr)</ShortName><Description>Wiktionnaire (fr)</Description><Image height="16" width="16" type="image/x-icon">https://fr.wiktionary.org/static/favicon/piece.ico</Image><Url type="text/html" method="get" template="https://fr.wiktionary.org/w/index.php?title=Sp%C3%A9cial:Recherche&amp;search={searchTerms}" /><Url type="application/x-suggestions+json" method="get" template="https://fr.wiktionary.org/w/api.php?action=opensearch&amp;search={searchTerms}&amp;namespace=100|106|0" /><Url type="application/x-suggestions+xml" method="get" template="https://fr.wiktionary.org/w/api.php?action=opensearch&amp;format=xml&amp;search={searchTerms}&amp;namespace=100|106|0" /><moz:SearchForm>https://fr.wiktionary.org/wiki/Sp%C3%A9cial:Recherche</moz:SearchForm></OpenSearchDescription>

--- a/WebSearch/src/main/assets/opensearch/wiktionary.xml
+++ b/WebSearch/src/main/assets/opensearch/wiktionary.xml
@@ -1,9 +1,1 @@
-<?xml version="1.0"?><OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
-	<ShortName>Wiktionary (en)</ShortName>
-	<Description>Dictionary and translator in the English language</Description>
-	<Image height="16" width="16" type="image/x-icon">https://en.wiktionary.org/favicon.ico</Image>
-	<Url type="text/html" method="get" template="https://en.wiktionary.org/w/index.php?title=Special:Search&amp;search={searchTerms}" />
-	<Url type="application/x-suggestions+json" method="get" template="https://en.wiktionary.org/w/api.php?action=opensearch&amp;search={searchTerms}&amp;namespace=0" />
-	<Url type="application/x-suggestions+xml" method="get" template="https://en.wiktionary.org/w/api.php?action=opensearch&amp;format=xml&amp;search={searchTerms}&amp;namespace=0" />
-	<moz:SearchForm>https://en.wiktionary.org/wiki/Special:Search</moz:SearchForm>
-</OpenSearchDescription>
+<?xml version="1.0"?><OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/"><ShortName>Wiktionary (en)</ShortName><Description>Wiktionary (en)</Description><Image height="16" width="16" type="image/x-icon">https://en.wiktionary.org/static/favicon/wiktionary/en.ico</Image><Url type="text/html" method="get" template="https://en.wiktionary.org/w/index.php?title=Special:Search&amp;search={searchTerms}" /><Url type="application/x-suggestions+json" method="get" template="https://en.wiktionary.org/w/api.php?action=opensearch&amp;search={searchTerms}&amp;namespace=0" /><Url type="application/x-suggestions+xml" method="get" template="https://en.wiktionary.org/w/api.php?action=opensearch&amp;format=xml&amp;search={searchTerms}&amp;namespace=0" /><moz:SearchForm>https://en.wiktionary.org/wiki/Special:Search</moz:SearchForm></OpenSearchDescription>

--- a/WebSearch/src/main/assets/opensearch/wiktionary.xml
+++ b/WebSearch/src/main/assets/opensearch/wiktionary.xml
@@ -5,5 +5,5 @@
 	<Url type="text/html" method="get" template="https://en.wiktionary.org/w/index.php?title=Special:Search&amp;search={searchTerms}" />
 	<Url type="application/x-suggestions+json" method="get" template="https://en.wiktionary.org/w/api.php?action=opensearch&amp;search={searchTerms}&amp;namespace=0" />
 	<Url type="application/x-suggestions+xml" method="get" template="https://en.wiktionary.org/w/api.php?action=opensearch&amp;format=xml&amp;search={searchTerms}&amp;namespace=0" />
-	<moz:SearchForm>https://en.wikipedia.org/wiki/Special:Search</moz:SearchForm>
+	<moz:SearchForm>https://en.wiktionary.org/wiki/Special:Search</moz:SearchForm>
 </OpenSearchDescription>

--- a/WebSearch/src/main/assets/opensearch/wiktionary.xml
+++ b/WebSearch/src/main/assets/opensearch/wiktionary.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?><OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+	<ShortName>Wiktionary (en)</ShortName>
+	<Description>Dictionary and translator in the English language</Description>
+	<Image height="16" width="16" type="image/x-icon">https://en.wiktionary.org/favicon.ico</Image>
+	<Url type="text/html" method="get" template="https://en.wiktionary.org/w/index.php?title=Special:Search&amp;search={searchTerms}" />
+	<Url type="application/x-suggestions+json" method="get" template="https://en.wiktionary.org/w/api.php?action=opensearch&amp;search={searchTerms}&amp;namespace=0" />
+	<Url type="application/x-suggestions+xml" method="get" template="https://en.wiktionary.org/w/api.php?action=opensearch&amp;format=xml&amp;search={searchTerms}&amp;namespace=0" />
+	<moz:SearchForm>https://en.wikipedia.org/wiki/Special:Search</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
First off, I'm not even familiar with XML and apologies for all the commits.

Fix many current engines to use TLS even though their opensearch.xml
hasn't been updated.

Add four new search providers: a web search engine, duckduckgo.com,
a regional Wikipedia and the same for Wiktionary. They can be easily
adapted to the user‘s favourite language.

Kickass and PirateBay favicons weren't showing but that could just be down to my ISP blocking them. I haven't been able to test the latter as I wasn't able to get a VPN to work on the phone I'm using.
